### PR TITLE
Pin RayDP to Ray's nightly builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,13 +20,15 @@ RayDP provides high level scikit-learn style Estimator APIs for distributed trai
 >
 > * In Spark 3.0 and 3.0.1 version, pyspark does not support user defined resource manager.
 
-Install ray with master branch and the given commit: `91d54ef621e16fc69e7f86800ded3ee60fd8b7f9`. You can follow the this [page](https://docs.ray.io/en/master/installation.html#installing-from-a-specific-commit) to install. The following is example to install the given commit ray:
+Install ray with the latest nigthly build. You can follow the this
+[page](https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl)
+to install. The following is example to install the given commit ray:
 
 ```python
 # python 3.7x linux
-pip install https://ray-wheels.s3-us-west-2.amazonaws.com/master/91d54ef621e16fc69e7f86800ded3ee60fd8b7f9/ray-1.1.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
+pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
 # python 3.7x MacOS
-pip install https://ray-wheels.s3-us-west-2.amazonaws.com/master/91d54ef621e16fc69e7f86800ded3ee60fd8b7f9/ray-1.1.0.dev0-cp37-cp37m-macosx_10_13_intel.whl
+pip install https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-2.0.0.dev0-cp37-cp37m-macosx_10_13_intel.whl
 ```
 
 You can build with the following command:

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -19,8 +19,21 @@
     <fasterxml.jackson.version>2.10.0</fasterxml.jackson.version>
     <jersey.version>2.30</jersey.version>
     <scala.binary.version>2.12</scala.binary.version>
-    <ray.version>1.0.1</ray.version>
+    <ray.version> 1.1.0-SNAPSHOT </ray.version>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>sonatype</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
+      <releases>
+        <enabled>false</enabled>
+      </releases>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+    </repository>
+  </repositories>
 
   <dependencies>
     <!-- https://mvnrepository.com/artifact/org.apache.spark/spark-sql -->
@@ -44,7 +57,6 @@
       <version>${ray.version}</version>
       <scope>provided</scope>
     </dependency>
-
     <dependency>
       <groupId>io.ray</groupId>
       <artifactId>ray-runtime</artifactId>

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/AppMasterJavaBridge.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/AppMasterJavaBridge.scala
@@ -32,7 +32,7 @@ class AppMasterJavaBridge {
       System.setProperty(key, value)
     }
     // Use the same session dir as the python side
-    RayConfig.getInstance().setSessionDir(System.getProperty("ray.session-dir"))
+    RayConfig.create().setSessionDir(System.getProperty("ray.session-dir"))
   }
 
   def startUpAppMaster(extra_cp: String): Unit = {

--- a/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
+++ b/core/src/main/scala/org/apache/spark/deploy/raydp/RayAppMaster.scala
@@ -38,11 +38,11 @@ class RayAppMaster(host: String,
   init()
 
   def this() = {
-    this(RayConfig.getInstance().nodeIp, 0, "")
+    this(RayConfig.create().nodeIp, 0, "")
   }
 
   def this(actor_extra_classpath: String) = {
-    this(RayConfig.getInstance().nodeIp, 0, actor_extra_classpath)
+    this(RayConfig.create().nodeIp, 0, actor_extra_classpath)
   }
 
   def init(): Unit = {

--- a/core/src/main/scala/org/apache/spark/executor/RayCoarseGrainedExecutorBackend.scala
+++ b/core/src/main/scala/org/apache/spark/executor/RayCoarseGrainedExecutorBackend.scala
@@ -38,7 +38,7 @@ class RayCoarseGrainedExecutorBackend(
     val executorId: String,
     val appMasterURL: String) extends Logging {
 
-  val nodeIp = RayConfig.getInstance().nodeIp
+  val nodeIp = RayConfig.create().nodeIp
 
   private val temporaryRpcEnvName = "ExecutorTemporaryRpcEnv"
   private var temporaryRpcEnv: Option[RpcEnv] = None
@@ -111,7 +111,7 @@ class RayCoarseGrainedExecutorBackend(
 
   def createWorkingDir(appId: String): Unit = {
     // create the application dir
-    val app_dir = new File(RayConfig.getInstance().sessionDir, appId)
+    val app_dir = new File(RayConfig.create().sessionDir, appId)
     var remainingTimes = 3
     var continue = true
     while (continue && remainingTimes > 0) {


### PR DESCRIPTION
This PR moves RayDP's Ray dependency to the Ray's nightly build (#78). I manually tested this on OS X and a small distributed cluster of Ubuntu machines. 

Please let me know if I'm missing some part of the contribution process!

A sample copy of the build wheel can be found [here.](https://anyscale-temp.s3-us-west-2.amazonaws.com/raydp-0.1.dev0-py2.py3-none-any.whl)